### PR TITLE
Fix incomplete file list

### DIFF
--- a/src/PimcoreDevkitBundle/Command/SynchronizeAssetsCommand.php
+++ b/src/PimcoreDevkitBundle/Command/SynchronizeAssetsCommand.php
@@ -92,11 +92,13 @@ class SynchronizeAssetsCommand extends AbstractCommand
      */
     public function listFolderFiles($dir)
     {
-        $ffs = rscandir($dir);
+        $files = rscandir($dir);
 
-        unset($ffs[array_search('.', $ffs, true)]);
-        unset($ffs[array_search('..', $ffs, true)]);
-
-        return $ffs;
+        return array_filter(
+            $files,
+            function ($filename) {
+                return $filename !== '.' && $filename !== '..';
+            }
+        );
     }
 }

--- a/src/PimcoreDevkitBundle/Command/SynchronizeAssetsCommand.php
+++ b/src/PimcoreDevkitBundle/Command/SynchronizeAssetsCommand.php
@@ -62,10 +62,20 @@ class SynchronizeAssetsCommand extends AbstractCommand
 
             $parentPath = substr(dirname($file), strlen(PIMCORE_ASSET_DIRECTORY)) . "/";
             $filename = basename($file);
+            $fileModificationDate = filemtime($file);
 
             // Does asset exist?
             $asset = Asset::getByPath($parentPath . $filename);
+
             if ($asset) {
+                if ($asset->getModificationDate() !== $fileModificationDate) {
+                    $asset->setModificationDate($fileModificationDate);
+                    $asset->save();
+                    $output->writeln(
+                        "Updated modification date for " . $parentPath . $filename . " (" . $asset->getType() . ")"
+                    );
+                }
+
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Short description of this Pull Request.
    
## Changes
### Fixed
- `devkit:asset:synchronize` skipping one file when the list doesn't include `.` or `..`

### Added
- `devkit:asset:synchronize` synchronizes modification date
