### PR TITLE
Fix createFieldcollectionDefinition

### DIFF
--- a/src/PimcoreDevkitBundle/Service/InstallerService.php
+++ b/src/PimcoreDevkitBundle/Service/InstallerService.php
@@ -240,7 +240,9 @@ class InstallerService
             $fieldcollection = FieldcollectionDefinition::getByKey($key);
         } catch (\Exception $exception) {
             $this->errors[] = $exception;
+        }
 
+        if (!$fieldcollection) {
             $fieldcollection = new FieldcollectionDefinition();
             $fieldcollection->setKey($key);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features / 3.4 up to 4.2 for bug fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Short description of this Pull Request.

If field colletnion does not exist, $fieldcollection is null and an error occurs:
`Call to a member function setLayoutDefinitions() on null`